### PR TITLE
Make API async

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,7 +19,6 @@ build: off
 notifications:
   - provider: Webhook
     url: https://webhooks.gitter.im/e/f39a577444275f34d7e1
-    method: GET
     on_build_success: false
     on_build_failure: true
     on_build_status_changed: true

--- a/src/format.test.ts
+++ b/src/format.test.ts
@@ -1,11 +1,16 @@
 import { NoLintersError } from "./errors";
 import { format } from "./format";
-import { LinterAdapter, registerLinter } from "./linter-map";
+import {
+  LinterAdapter,
+  LinterAdapterFormat,
+  LinterAdapterLint,
+  registerLinter
+} from "./linter-map";
 
 describe("Format", () => {
   const linterAdapter: LinterAdapter = {
-    formatSync: jest.fn(({ text }) => text),
-    lintSync: jest.fn(() => ({}))
+    format: jest.fn<LinterAdapterFormat>(({ text }) => text),
+    lint: jest.fn<LinterAdapterLint>(() => ({}))
   };
 
   const linterFactory = jest.fn(() => linterAdapter);
@@ -20,7 +25,7 @@ describe("Format", () => {
     const args = { text: 'const foo = "bar"' };
     const result = await format(args);
     expect(result).toBe(args.text);
-    expect(linterAdapter.formatSync).toHaveBeenCalledTimes(1);
-    expect(linterAdapter.formatSync).toHaveBeenCalledWith(args);
+    expect(linterAdapter.format).toHaveBeenCalledTimes(1);
+    expect(linterAdapter.format).toHaveBeenCalledWith(args);
   });
 });

--- a/src/format.test.ts
+++ b/src/format.test.ts
@@ -13,6 +13,10 @@ describe("Format", () => {
     lint: jest.fn<LinterAdapterLint>(() => ({}))
   };
 
+  const prettierLinterAdapter: LinterAdapter = {
+    format: jest.fn<LinterAdapterFormat>(({ text }) => `prettier:${text}`),
+    lint: jest.fn<LinterAdapterLint>(() => ({}))
+  };
 
   test("No registered linters", async () => {
     const promise = format({ text: 'const foo = "bar"' });
@@ -26,5 +30,18 @@ describe("Format", () => {
     expect(result).toEqual(args.text);
     expect(linterAdapter.format).toHaveBeenCalledTimes(1);
     expect(linterAdapter.format).toHaveBeenCalledWith(args);
+  });
+
+  test("Format with filePath", async () => {
+    const args = { filePath: "test.js", text: 'const foo = "bar"' };
+    const result = await format(args);
+    expect(result).toEqual(args.text);
+  });
+
+  test("Format with prettier registered", async () => {
+    registerLinter("prettier", () => prettierLinterAdapter);
+    const args = { text: 'const foo = "bar"' };
+    const result = await format(args);
+    expect(result).toEqual(`prettier:${args.text}`);
   });
 });

--- a/src/format.test.ts
+++ b/src/format.test.ts
@@ -24,7 +24,7 @@ describe("Format", () => {
     registerLinter("testLinter", linterFactory);
     const args = { text: 'const foo = "bar"' };
     const result = await format(args);
-    expect(result).toBe(args.text);
+    expect(result).toEqual(args.text);
     expect(linterAdapter.format).toHaveBeenCalledTimes(1);
     expect(linterAdapter.format).toHaveBeenCalledWith(args);
   });

--- a/src/format.test.ts
+++ b/src/format.test.ts
@@ -4,23 +4,23 @@ import { LinterAdapter, registerLinter } from "./linter-map";
 
 describe("Format", () => {
   const linterAdapter: LinterAdapter = {
-    format: jest.fn(({ text }) => text),
-    lint: jest.fn(() => ({}))
+    formatSync: jest.fn(({ text }) => text),
+    lintSync: jest.fn(() => ({}))
   };
 
   const linterFactory = jest.fn(() => linterAdapter);
 
-  test("No registered linters", () => {
-    expect(() => {
-      format({ text: 'const foo = "bar"' });
-    }).toThrowError(NoLintersError);
+  test("No registered linters", async () => {
+    const promise = format({ text: 'const foo = "bar"' });
+    expect(promise).rejects.toBeInstanceOf(NoLintersError);
   });
 
-  test("Format", () => {
+  test("Format", async () => {
     registerLinter("testLinter", linterFactory);
     const args = { text: 'const foo = "bar"' };
-    expect(format(args)).toBe(args.text);
-    expect(linterAdapter.format).toHaveBeenCalledTimes(1);
-    expect(linterAdapter.format).toHaveBeenCalledWith(args);
+    const result = await format(args);
+    expect(result).toBe(args.text);
+    expect(linterAdapter.formatSync).toHaveBeenCalledTimes(1);
+    expect(linterAdapter.formatSync).toHaveBeenCalledWith(args);
   });
 });

--- a/src/format.test.ts
+++ b/src/format.test.ts
@@ -13,7 +13,6 @@ describe("Format", () => {
     lint: jest.fn<LinterAdapterLint>(() => ({}))
   };
 
-  const linterFactory = jest.fn(() => linterAdapter);
 
   test("No registered linters", async () => {
     const promise = format({ text: 'const foo = "bar"' });
@@ -21,7 +20,7 @@ describe("Format", () => {
   });
 
   test("Format", async () => {
-    registerLinter("testLinter", linterFactory);
+    registerLinter("testLinter", () => linterAdapter);
     const args = { text: 'const foo = "bar"' };
     const result = await format(args);
     expect(result).toEqual(args.text);

--- a/src/format.ts
+++ b/src/format.ts
@@ -16,9 +16,9 @@ export async function format(input: FormatInput): Promise<FormatOutput> {
   const linters: [string, LinterAdapter][] = [];
   for (const [name, linterFactory] of linterMap) {
     if (name === "prettier") {
-      linters.unshift([name, linterFactory()]);
+      linters.unshift([name, await linterFactory()]);
     } else {
-      linters.push([name, linterFactory()]);
+      linters.push([name, await linterFactory()]);
     }
   }
 

--- a/src/format.ts
+++ b/src/format.ts
@@ -1,9 +1,4 @@
-import {
-  linterMap,
-  LinterAdapter,
-  LinterAdapterFormatAsync,
-  LinterAdapterFormatSync
-} from "./linter-map";
+import { linterMap, LinterAdapter } from "./linter-map";
 import { NoLintersError } from "./errors";
 
 export interface FormatInput {
@@ -12,12 +7,6 @@ export interface FormatInput {
 }
 
 export type FormatOutput = string;
-
-function hasSyncFormat(
-  linter: LinterAdapterFormatAsync | LinterAdapterFormatSync
-): linter is LinterAdapterFormatSync {
-  return (<LinterAdapterFormatSync>linter).formatSync !== undefined;
-}
 
 export async function format(input: FormatInput): Promise<FormatOutput> {
   if (linterMap.size === 0) {
@@ -38,9 +27,7 @@ export async function format(input: FormatInput): Promise<FormatOutput> {
       const { filePath, text } = await output;
       return {
         ...(filePath && { filePath }),
-        text: hasSyncFormat(linter)
-          ? linter.formatSync({ filePath, text })
-          : await linter.format({ filePath, text })
+        text: await linter.format({ filePath, text })
       };
     },
     Promise.resolve({ ...input })

--- a/src/format.ts
+++ b/src/format.ts
@@ -1,5 +1,5 @@
-import { linterMap, LinterAdapter } from "./linter-map";
 import { NoLintersError } from "./errors";
+import { linterMap, LinterAdapter } from "./linter-map";
 
 export interface FormatInput {
   filePath?: string;

--- a/src/lint.test.ts
+++ b/src/lint.test.ts
@@ -13,15 +13,13 @@ describe("Lint", () => {
     lint: jest.fn<LinterAdapterLint>(() => ({}))
   };
 
-  const linterFactory = jest.fn(() => linterAdapter);
-
   test("No registered linters", () => {
     const promise = lint({ text: 'const foo = "bar"' });
     expect(promise).rejects.toBeInstanceOf(NoLintersError);
   });
 
   test("Lint", async () => {
-    registerLinter("testLinter", linterFactory);
+    registerLinter("testLinter", () => linterAdapter);
     const args = { text: 'const foo = "bar"' };
     const result = await lint(args);
     const isArray = Array.isArray(result);

--- a/src/lint.test.ts
+++ b/src/lint.test.ts
@@ -1,16 +1,16 @@
 import { NoLintersError } from "./errors";
 import { lint } from "./lint";
 import {
-  registerLinter,
   LinterAdapter,
-  LinterAdapterFormatSync,
-  LinterAdapterLintSync
+  LinterAdapterFormat,
+  LinterAdapterLint,
+  registerLinter
 } from "./linter-map";
 
 describe("Lint", () => {
   const linterAdapter: LinterAdapter = {
-    formatSync: jest.fn<LinterAdapterFormatSync>(({ text }) => text),
-    lintSync: jest.fn<LinterAdapterLintSync>(() => ({}))
+    format: jest.fn<LinterAdapterFormat>(({ text }) => text),
+    lint: jest.fn<LinterAdapterLint>(() => ({}))
   };
 
   const linterFactory = jest.fn(() => linterAdapter);
@@ -26,7 +26,7 @@ describe("Lint", () => {
     const result = await lint(args);
     const isArray = Array.isArray(result);
     expect(isArray).toBeTruthy();
-    expect(linterAdapter.lintSync).toHaveBeenCalledTimes(1);
-    expect(linterAdapter.lintSync).toHaveBeenCalledWith(args);
+    expect(linterAdapter.lint).toHaveBeenCalledTimes(1);
+    expect(linterAdapter.lint).toHaveBeenCalledWith(args);
   });
 });

--- a/src/lint.ts
+++ b/src/lint.ts
@@ -2,9 +2,7 @@ import { NoLintersError } from "./errors";
 import {
   linterMap,
   LinterAdapterLintOutput,
-  LinterAdapter,
-  LinterAdapterLintAsync,
-  LinterAdapterLintSync
+  LinterAdapter
 } from "./linter-map";
 
 export interface LintInput {
@@ -13,12 +11,6 @@ export interface LintInput {
 }
 
 export type LintOutput = LinterAdapterLintOutput[];
-
-function hasSyncLint(
-  linter: LinterAdapterLintAsync | LinterAdapterLintSync
-): linter is LinterAdapterLintSync {
-  return (<LinterAdapterLintSync>linter).lintSync !== undefined;
-}
 
 export async function lint({ filePath, text }: LintInput): Promise<LintOutput> {
   if (linterMap.size === 0) {
@@ -33,10 +25,7 @@ export async function lint({ filePath, text }: LintInput): Promise<LintOutput> {
   // Run text through all linters
   // XXX: Linting should be able to be done in parallel
   const lintArgs = { filePath, text };
-  const lintOutput = linters.map(
-    async linter =>
-      hasSyncLint(linter) ? linter.lintSync(lintArgs) : linter.lint(lintArgs)
-  );
+  const lintOutput = linters.map(async linter => await linter.lint(lintArgs));
 
   // XXX: Could we return a streaming result for the cli if we lint in parallel?
   // This way the cli could add the linter results for each file as they become

--- a/src/lint.ts
+++ b/src/lint.ts
@@ -19,7 +19,7 @@ export async function lint({ filePath, text }: LintInput): Promise<LintOutput> {
 
   const linters: LinterAdapter[] = [];
   for (const linterFactory of linterMap.values()) {
-    linters.push(linterFactory());
+    linters.push(await linterFactory());
   }
 
   // Run text through all linters

--- a/src/linter-map.test.ts
+++ b/src/linter-map.test.ts
@@ -3,13 +3,15 @@ import {
   linterMap,
   registerLinter,
   LinterAdapter,
-  LinterFactory
+  LinterFactory,
+  LinterAdapterFormatSync,
+  LinterAdapterLintSync
 } from "./linter-map";
 
 describe("Linters", () => {
-  const linterFactory = jest.fn(() => ({
-    format: jest.fn(() => ({})),
-    lint: jest.fn(() => ({}))
+  const linterFactory: LinterFactory = jest.fn<LinterAdapter>(() => ({
+    formatSync: jest.fn<LinterAdapterFormatSync>(() => ({})),
+    lintSync: jest.fn<LinterAdapterLintSync>(() => ({}))
   }));
 
   test("Register linter", () => {

--- a/src/linter-map.test.ts
+++ b/src/linter-map.test.ts
@@ -1,17 +1,17 @@
 import { DuplicateLinterError } from "./errors";
 import {
-  linterMap,
-  registerLinter,
   LinterAdapter,
+  LinterAdapterFormat,
+  LinterAdapterLint,
   LinterFactory,
-  LinterAdapterFormatSync,
-  LinterAdapterLintSync
+  linterMap,
+  registerLinter
 } from "./linter-map";
 
 describe("Linters", () => {
   const linterFactory: LinterFactory = jest.fn<LinterAdapter>(() => ({
-    formatSync: jest.fn<LinterAdapterFormatSync>(() => ({})),
-    lintSync: jest.fn<LinterAdapterLintSync>(() => ({}))
+    format: jest.fn<LinterAdapterFormat>(() => ({})),
+    lint: jest.fn<LinterAdapterLint>(() => ({}))
   }));
 
   test("Register linter", () => {

--- a/src/linter-map.ts
+++ b/src/linter-map.ts
@@ -30,7 +30,7 @@ export interface LinterAdapter {
 }
 
 // TODO: Support config, configPath, modulePath, etc
-export type LinterFactory = () => LinterAdapter;
+export type LinterFactory = () => LinterAdapter | Promise<LinterAdapter>;
 
 export const linterMap = new Map<string, LinterFactory>();
 

--- a/src/linter-map.ts
+++ b/src/linter-map.ts
@@ -14,15 +14,44 @@ export interface LinterAdapterLintInput {
 
 export interface LinterAdapterLintOutput {}
 
-// XXX: LinterAdapters decide if they do anything with text baed on filePath and text
-// Do we need to forward more info to LinterAdapters?
-export interface LinterAdapter {
+export interface LinterAdapterFormatAsync {
   format({
     filePath,
     text
-  }: LinterAdapterFormatInput): LinterAdapterFormatOutput;
-  lint({ filePath, text }: LinterAdapterLintInput): LinterAdapterLintOutput;
+  }: LinterAdapterFormatInput): Promise<LinterAdapterFormatOutput>;
 }
+
+export interface LinterAdapterFormatSync {
+  formatSync({
+    filePath,
+    text
+  }: LinterAdapterFormatInput): LinterAdapterFormatOutput;
+}
+
+export type LinterAdapterFormat =
+  | LinterAdapterFormatAsync
+  | LinterAdapterFormatSync
+  | (LinterAdapterFormatAsync & LinterAdapterFormatSync);
+
+export interface LinterAdapterLintAsync {
+  lint({
+    filePath,
+    text
+  }: LinterAdapterLintInput): Promise<LinterAdapterLintOutput>;
+}
+
+export interface LinterAdapterLintSync {
+  lintSync({ filePath, text }: LinterAdapterLintInput): LinterAdapterLintOutput;
+}
+
+export type LinterAdapterLint =
+  | LinterAdapterLintAsync
+  | LinterAdapterLintSync
+  | (LinterAdapterLintAsync & LinterAdapterLintSync);
+
+// XXX: LinterAdapters decide if they do anything with text based on filePath and text
+// Do we need to forward more info to LinterAdapters?
+export type LinterAdapter = LinterAdapterFormat & LinterAdapterLint;
 
 // TODO: Support config, configPath, modulePath, etc
 export type LinterFactory = () => LinterAdapter;

--- a/src/linter-map.ts
+++ b/src/linter-map.ts
@@ -14,44 +14,20 @@ export interface LinterAdapterLintInput {
 
 export interface LinterAdapterLintOutput {}
 
-export interface LinterAdapterFormatAsync {
-  format({
-    filePath,
-    text
-  }: LinterAdapterFormatInput): Promise<LinterAdapterFormatOutput>;
-}
+export type LinterAdapterFormat = (
+  { filePath, text }: LinterAdapterFormatInput
+) => LinterAdapterFormatOutput | Promise<LinterAdapterFormatOutput>;
 
-export interface LinterAdapterFormatSync {
-  formatSync({
-    filePath,
-    text
-  }: LinterAdapterFormatInput): LinterAdapterFormatOutput;
-}
-
-export type LinterAdapterFormat =
-  | LinterAdapterFormatAsync
-  | LinterAdapterFormatSync
-  | (LinterAdapterFormatAsync & LinterAdapterFormatSync);
-
-export interface LinterAdapterLintAsync {
-  lint({
-    filePath,
-    text
-  }: LinterAdapterLintInput): Promise<LinterAdapterLintOutput>;
-}
-
-export interface LinterAdapterLintSync {
-  lintSync({ filePath, text }: LinterAdapterLintInput): LinterAdapterLintOutput;
-}
-
-export type LinterAdapterLint =
-  | LinterAdapterLintAsync
-  | LinterAdapterLintSync
-  | (LinterAdapterLintAsync & LinterAdapterLintSync);
+export type LinterAdapterLint = (
+  { filePath, text }: LinterAdapterLintInput
+) => LinterAdapterLintOutput | Promise<LinterAdapterLintOutput>;
 
 // XXX: LinterAdapters decide if they do anything with text based on filePath and text
 // Do we need to forward more info to LinterAdapters?
-export type LinterAdapter = LinterAdapterFormat & LinterAdapterLint;
+export interface LinterAdapter {
+  format: LinterAdapterFormat;
+  lint: LinterAdapterLint;
+}
 
 // TODO: Support config, configPath, modulePath, etc
 export type LinterFactory = () => LinterAdapter;


### PR DESCRIPTION
This makes `format` and `lint` async. This was needed to support the linters out there that does not have a sync API.

The LinterAdapter interface supports `formatAsync`, `formatSync`, `lintAsync` and `lintSync`. At least one format and lint function needs to be present on the linterAdapter that is being registered.

In the `format` and `lint` functions sync versions of the LinterAdapter's functions take presidence over the async versions. I don't know if this the best choice?