### PR TITLE
Return an array of promises from lint

### DIFF
--- a/src/__snapshots__/lint.test.ts.snap
+++ b/src/__snapshots__/lint.test.ts.snap
@@ -2,6 +2,6 @@
 
 exports[`Lint Lint 1`] = `
 Array [
-  Object {},
+  Promise {},
 ]
 `;

--- a/src/lint.test.ts
+++ b/src/lint.test.ts
@@ -12,8 +12,7 @@ describe("Lint", () => {
   const text = 'const foo = "bar"';
 
   test("No registered linters", () => {
-    const promise = lint({ text });
-    expect(promise).rejects.toBeInstanceOf(NoLintersError);
+    expect(() => lint({ text })).toThrowError(NoLintersError);
   });
 
   test("Lint", async () => {

--- a/src/lint.ts
+++ b/src/lint.ts
@@ -1,33 +1,14 @@
 import { NoLintersError } from "./errors";
-import {
-  linterMap,
-  LinterAdapterLintOutput,
-  LinterAdapter
-} from "./linter-map";
+import { linterMap, LinterAdapterLintOutput } from "./linter-map";
 
 export interface LintInput {
   filePath?: string;
-  returnArray: boolean;
   text: string;
 }
 
-export interface LintInputReturnArray extends LintInput {
-  returnArray: true;
-}
+export type LintOutput = Promise<LinterAdapterLintOutput>[];
 
-export interface LintInputReturnPromise extends LintInput {
-  returnArray: false;
-}
-
-export type LintOutputArray = LinterAdapterLintOutput[];
-
-export type LintOutputPromise = Promise<LinterAdapterLintOutput[]>;
-
-export type LintOutput = LintOutputArray | LintOutputPromise;
-
-export function lint(args: LintInputReturnArray): LintOutputArray;
-export function lint(args: LintInputReturnPromise): LintOutputPromise;
-export function lint({ filePath, text, returnArray = false }: LintInput): LintOutput {
+export function lint({ filePath, text }: LintInput): LintOutput {
   if (linterMap.size === 0) {
     throw new NoLintersError();
   }
@@ -44,5 +25,5 @@ export function lint({ filePath, text, returnArray = false }: LintInput): LintOu
   // XXX: Could we return a streaming result for the cli if we lint in parallel?
   // This way the cli could add the linter results for each file as they become
   // available.
-  return returnArray ? lintOutput : Promise.all(lintOutput);
+  return lintOutput;
 }

--- a/src/lint.ts
+++ b/src/lint.ts
@@ -7,28 +7,45 @@ import {
 
 export interface LintInput {
   filePath?: string;
+  returnArray: boolean;
   text: string;
 }
 
-export type LintOutput = LinterAdapterLintOutput[];
+export interface LintInputReturnArray extends LintInput {
+  returnArray: true;
+}
 
-export async function lint({ filePath, text }: LintInput): Promise<LintOutput> {
+export interface LintInputReturnPromise extends LintInput {
+  returnArray: false;
+}
+
+export type LintOutputArray = LinterAdapterLintOutput[];
+
+export type LintOutputPromise = Promise<LinterAdapterLintOutput[]>;
+
+export type LintOutput = LintOutputArray | LintOutputPromise;
+
+export function lint(args: LintInputReturnArray): LintOutputArray;
+export function lint(args: LintInputReturnPromise): LintOutputPromise;
+export function lint({ filePath, text, returnArray }: LintInput): LintOutput {
   if (linterMap.size === 0) {
     throw new NoLintersError();
   }
 
-  const linters: LinterAdapter[] = [];
+  const linters: (LinterAdapter | Promise<LinterAdapter>)[] = [];
   for (const linterFactory of linterMap.values()) {
-    linters.push(await linterFactory());
+    linters.push(linterFactory());
   }
 
   // Run text through all linters
   // XXX: Linting should be able to be done in parallel
   const lintArgs = { filePath, text };
-  const lintOutput = linters.map(async linter => await linter.lint(lintArgs));
+  const lintOutput = linters.map(
+    async linter => await (await linter).lint(lintArgs)
+  );
 
   // XXX: Could we return a streaming result for the cli if we lint in parallel?
   // This way the cli could add the linter results for each file as they become
   // available.
-  return Promise.all(lintOutput);
+  return returnArray ? lintOutput : Promise.all(lintOutput);
 }

--- a/src/lint.ts
+++ b/src/lint.ts
@@ -27,7 +27,7 @@ export type LintOutput = LintOutputArray | LintOutputPromise;
 
 export function lint(args: LintInputReturnArray): LintOutputArray;
 export function lint(args: LintInputReturnPromise): LintOutputPromise;
-export function lint({ filePath, text, returnArray }: LintInput): LintOutput {
+export function lint({ filePath, text, returnArray = false }: LintInput): LintOutput {
   if (linterMap.size === 0) {
     throw new NoLintersError();
   }


### PR DESCRIPTION
Add an option to return an array of `Promise<LinterAdapterLintOutput>`.

I'm not sure this makes sense, but I'm thinking that the consumer of the api could have a use case for wanting to wait for individual linter results instead of having to wait for all results to resolve before being able to access them.

@azz Thoughts?